### PR TITLE
build(zlib): track upstream main to fix Zig 0.15.1 build failure

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "N-V-__8AABcPXgCefxVc22OCflvY-XJlYQOQtWGJX3ZGucCm",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/refs/tags/1.3.1.tar.gz",
-            .hash = "zlib-1.3.1-AAAAACEMAAA0qyoSrfgBb_p25ItL4yRf_TBRk-26TYMF",
+            .url = "git+https://github.com/allyourcodebase/zlib.git?ref=main#61e7df7e996ec5a5f13a653db3c419adb340d6ef",
+            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
         },
         .bzip2 = .{
             .url = "git+https://github.com/allyourcodebase/bzip2.git?ref=1.0.8#d7668d5ee5eb55489c35632ecf0b0107c7a77569",


### PR DESCRIPTION
The previous zlib dependency build.zig relied on deprecated addStaticLibrary, so build breaks on Zig 0.15.1.

Switch to the current upstream zlib main branch to restore successful builds of the libzip and all the code which depends on libzip.